### PR TITLE
Fix build failure in CI using temporary workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
 
 
 install:
+  # TODO: Remove once source code is fixed for sodafoundation
+  - ln -s $GOPATH/src/sodafoundation $GOPATH/src/opensds
   # Build OpenSDS Controller source code
   - make all
 


### PR DESCRIPTION
**What this PR does / why we need it**:
CI build fails as go import path is not migrated to sodafoundation. Use temporary workaround of creating soft link to fix this.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
