### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/cmd/osdsdock/Dockerfile
+++ b/cmd/osdsdock/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER Leon Wang <wanghui71leon@gmail.com>
 COPY osdsdock /usr/bin
 
 # Install some packages before running command.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
  librados-dev librbd-dev ceph-common lvm2 udev tgt \
  && rm -rf /var/lib/apt
 RUN sed -i -e 's/udev_sync = 1/udev_sync = 0/g' /etc/lvm/lvm.conf \

--- a/install/devsds/bootstrap.sh
+++ b/install/devsds/bootstrap.sh
@@ -84,7 +84,7 @@ fi
 # make sure 'make' has been installed.
 if [[ -z "$(which make)" ]]; then
     log "Installing make ..."
-    sudo apt-get install make -y
+    sudo apt-get --no-install-recommends install make -y
 fi
 
 cd ${OPENSDS_DIR}

--- a/install/devsds/lib/lvm.sh
+++ b/install/devsds/lib/lvm.sh
@@ -48,11 +48,11 @@ NVME_DIR=/opt/opensdsNvme
 LVM_DEVICE=/dev/nvme0n1
 
 osds::lvm::pkg_install(){
-    sudo apt-get install -y lvm2 tgt open-iscsi ibverbs-utils
+    sudo apt-get --no-install-recommends install -y lvm2 tgt open-iscsi ibverbs-utils
 }
 
 osds::nfs::pkg_install(){
-    sudo apt-get install -y nfs-kernel-server
+    sudo apt-get --no-install-recommends install -y nfs-kernel-server
 }
 
 osds::lvm::pkg_uninstall(){

--- a/install/opensds-authchecker/Dockerfile
+++ b/install/opensds-authchecker/Dockerfile
@@ -14,7 +14,7 @@ COPY keystone.sh /keystone.sh
 COPY entrypoint.sh /entrypoint.sh
 
 # Install some packages before running command.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
     sudo nano git telnet net-tools iptables gnutls-bin ca-certificates && \
     mkdir -p /opt/stack/
 


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
